### PR TITLE
update for dealing with big dataset (size_t, remove conversion from distance to matrix) and verbose for running details, etc.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ distanceToPeakCpp <- function(distance, rho) {
     .Call('densityClust_distanceToPeakCpp', PACKAGE = 'densityClust', distance, rho)
 }
 
+findDistValueByRowColInd <- function(distance, num_row, row_inds, col_inds) {
+    .Call('densityClust_findDistValueByRowColInd', PACKAGE = 'densityClust', distance, num_row, row_inds, col_inds)
+}
+
 gaussianLocalDensity <- function(distance, nrow, dc) {
     .Call('densityClust_gaussianLocalDensity', PACKAGE = 'densityClust', distance, nrow, dc)
 }

--- a/man/densityClust.Rd
+++ b/man/densityClust.Rd
@@ -4,7 +4,7 @@
 \alias{densityClust}
 \title{Calculate clustering attributes based on the densityClust algorithm}
 \usage{
-densityClust(distance, dc, gaussian = FALSE)
+densityClust(distance, dc, gaussian = FALSE, verbose = F)
 }
 \arguments{
 \item{distance}{A distance matrix}
@@ -14,6 +14,8 @@ will be estimated with estimateDc(distance)}
 
 \item{gaussian}{Logical. Should a gaussian kernel be used to estimate the 
 density (defaults to FALSE)}
+
+\item{verbose}{Logical. Should the running details be reported}
 }
 \value{
 A densityCluster object. See details for a description.

--- a/man/findClusters.Rd
+++ b/man/findClusters.Rd
@@ -7,7 +7,8 @@
 \usage{
 findClusters(x, ...)
 
-\method{findClusters}{densityCluster}(x, rho, delta, plot = FALSE, ...)
+\method{findClusters}{densityCluster}(x, rho, delta, plot = FALSE,
+  peaks = NULL, verbose = F, ...)
 }
 \arguments{
 \item{x}{A densityCluster object as produced by \code{\link{densityClust}}}
@@ -19,6 +20,10 @@ findClusters(x, ...)
 \item{delta}{The threshold for minimum distance to higher density when detecting cluster peaks}
 
 \item{plot}{Logical. Should a decision plot be shown after cluster detection}
+
+\item{peaks}{A numeric vector indicates the index of density peaks used for clustering. This vector should be retrieved from the decision plot with caution. No checking involved.}
+
+\item{verbose}{Logical. Should the running details be reported}
 }
 \value{
 A densityCluster object with clusters assigned to all observations

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,27 +17,41 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// findDistValueByRowColInd
+NumericVector findDistValueByRowColInd(NumericVector distance, size_t num_row, NumericVector row_inds, NumericVector col_inds);
+RcppExport SEXP densityClust_findDistValueByRowColInd(SEXP distanceSEXP, SEXP num_rowSEXP, SEXP row_indsSEXP, SEXP col_indsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< NumericVector >::type distance(distanceSEXP);
+    Rcpp::traits::input_parameter< size_t >::type num_row(num_rowSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type row_inds(row_indsSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type col_inds(col_indsSEXP);
+    __result = Rcpp::wrap(findDistValueByRowColInd(distance, num_row, row_inds, col_inds));
+    return __result;
+END_RCPP
+}
 // gaussianLocalDensity
-NumericVector gaussianLocalDensity(NumericVector distance, int nrow, double dc);
+NumericVector gaussianLocalDensity(NumericVector distance, size_t nrow, double dc);
 RcppExport SEXP densityClust_gaussianLocalDensity(SEXP distanceSEXP, SEXP nrowSEXP, SEXP dcSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< NumericVector >::type distance(distanceSEXP);
-    Rcpp::traits::input_parameter< int >::type nrow(nrowSEXP);
+    Rcpp::traits::input_parameter< size_t >::type nrow(nrowSEXP);
     Rcpp::traits::input_parameter< double >::type dc(dcSEXP);
     __result = Rcpp::wrap(gaussianLocalDensity(distance, nrow, dc));
     return __result;
 END_RCPP
 }
 // nonGaussianLocalDensity
-NumericVector nonGaussianLocalDensity(NumericVector distance, int nrow, double dc);
+NumericVector nonGaussianLocalDensity(NumericVector distance, size_t nrow, double dc);
 RcppExport SEXP densityClust_nonGaussianLocalDensity(SEXP distanceSEXP, SEXP nrowSEXP, SEXP dcSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< NumericVector >::type distance(distanceSEXP);
-    Rcpp::traits::input_parameter< int >::type nrow(nrowSEXP);
+    Rcpp::traits::input_parameter< size_t >::type nrow(nrowSEXP);
     Rcpp::traits::input_parameter< double >::type dc(dcSEXP);
     __result = Rcpp::wrap(nonGaussianLocalDensity(distance, nrow, dc));
     return __result;

--- a/src/distanceToPeak.cpp
+++ b/src/distanceToPeak.cpp
@@ -3,13 +3,13 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector distanceToPeakCpp(NumericVector distance, NumericVector rho) {
-   int size = rho.size();
+   size_t size = rho.size();
    NumericVector peaks(size);
    NumericVector maximum(size);
    
-   int i = 0;
-   for (int col = 0; col < size; col++) {
-      for (int row = col + 1; row < size; row++) {
+   size_t i = 0;
+   for (size_t col = 0; col < size; col++) {
+      for (size_t row = col + 1; row < size; row++) {
          double newValue = distance[i];
          double rhoRow = rho[row];
          double rhoCol = rho[col];
@@ -35,7 +35,7 @@ NumericVector distanceToPeakCpp(NumericVector distance, NumericVector rho) {
       }
    }
    
-   for (int j = 0; j < size; j++) {
+   for (size_t j = 0; j < size; j++) {
       if (peaks[j] == 0) {
          peaks[j] = maximum[j];
       } else {

--- a/src/findDistValueByRowColInd.cpp
+++ b/src/findDistValueByRowColInd.cpp
@@ -1,0 +1,72 @@
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// This is a simple example of exporting a C++ function to R. You can
+// source this function into an R session using the Rcpp::sourceCpp 
+// function (or via the Source button on the editor toolbar). Learn
+// more about Rcpp at:
+//
+//   http://www.rcpp.org/
+//   http://adv-r.had.co.nz/Rcpp.html
+//   http://gallery.rcpp.org/
+//
+
+// [[Rcpp::export]]
+NumericVector findDistValueByRowColInd(NumericVector distance, size_t num_row, NumericVector row_inds,  NumericVector col_inds) {
+  size_t row_inds_len = row_inds.size();
+  size_t col_inds_len = col_inds.size();
+  NumericVector res(row_inds_len * col_inds_len);
+
+  // Rcout << "distance is " << distance  << "col_inds index is " << col_inds << std::endl; 
+  // Rcout << "row_inds is " << row_inds  << "col_inds index is " << col_inds << std::endl;
+  // Rcout << "col_inds_len is " << col_inds_len  << "col_inds_len index is " << col_inds_len  << "res length is " << res.size() << std::endl;
+  
+  size_t i = 0;
+  size_t dist_ind; 
+
+  for (size_t row = 0; row < row_inds_len; row++) {
+    size_t row_ind = row_inds[row];
+    for (size_t col = 0; col < col_inds_len; col++) {
+      size_t col_ind = col_inds[col];
+      // Rcout << "col is " << col  << "row is " << row << std::endl;
+
+      if(row_ind == col_ind){
+        res[i] = 0;
+      }
+      else{
+        size_t row_ind_new; 
+        size_t col_ind_new; 
+
+        if(col_ind > row_ind) {
+          size_t row_ind_tmp = row_ind; 
+          size_t col_ind_tmp = col_ind;
+          row_ind_new = col_ind_tmp;
+          col_ind_new = row_ind_tmp;
+        }
+        else{
+          row_ind_new = row_ind;
+          col_ind_new = col_ind;          
+        }
+         dist_ind = num_row * (col_ind_new - 1) + row_ind_new - 0.5 * (1 + col_ind_new) * col_ind_new - 1;
+         // if(row_ind == 3 && col_ind == 2){
+          // Rcout << "num_row * (col_ind_new - 1) is " << num_row * (col_ind_new - 1)  << " 1/2 * (1 + col_ind_new) * col_ind_new is " << 0.5 * (1 + 1) * col_ind_new  << " num_row is " << num_row << " dist_ind is " << num_row * (col_ind_new - 1) + row_ind_new - 1/2 * (1 + col_ind_new) * col_ind_new - 1 << std::endl;
+
+          // Rcout << "col_ind_new is " << col_ind_new  << " row_ind_new index is " << row_ind_new  << " num_row is " << num_row << " dist_ind is " << dist_ind << " distance under the current index " << distance[dist_ind] << std::endl;
+         // }
+         res[i] = distance[dist_ind]; 
+      }
+      i++; 
+    }
+  }
+  
+  return res;
+}
+
+// You can include R code blocks in C++ files processed with sourceCpp
+// (useful for testing and development). The R code will be automatically 
+// run after the compilation.
+//
+
+/*** R
+findDistValueByRowColInd(test, attr(test, 'Size'), 1:100, 1:100)
+*/

--- a/src/localDensity.cpp
+++ b/src/localDensity.cpp
@@ -2,21 +2,21 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-NumericVector gaussianLocalDensity(NumericVector distance, int nrow, double dc) {
-   int size = distance.size();
+NumericVector gaussianLocalDensity(NumericVector distance, size_t nrow, double dc) {
+   size_t size = distance.size();
    NumericVector half(size);
-   for (int i = 0; i < size; i++) {
+   for (size_t i = 0; i < size; i++) {
       double combOver = distance[i] / dc;
       double negSq = pow(combOver, 2) * -1;
       half[i] = exp(negSq);
    }     
-   int ncol = nrow;
+   size_t ncol = nrow;
    
    NumericVector result(nrow);
    
-   int i = 0;
-   for (int col = 0; col < ncol; col++) {
-      for (int row = col + 1; row < nrow; row++) {
+   size_t i = 0;
+   for (size_t col = 0; col < ncol; col++) {
+      for (size_t row = col + 1; row < nrow; row++) {
          double temp = half[i];
          result[row] += temp;
          result[col] += temp;
@@ -28,12 +28,20 @@ NumericVector gaussianLocalDensity(NumericVector distance, int nrow, double dc) 
 }
 
 // [[Rcpp::export]]
-NumericVector nonGaussianLocalDensity(NumericVector distance, int nrow, double dc) {
-   int ncol = nrow;
+NumericVector nonGaussianLocalDensity(NumericVector distance, size_t nrow, double dc) {
+   size_t ncol = nrow;
    NumericVector result(nrow);
-   int i = 0;
-   for (int col = 0; col < ncol; col++) {
-      for (int row = col + 1; row < nrow; row++) {
+   size_t i = 0;
+   for (size_t col = 0; col < ncol; col++) {
+      for (size_t row = col + 1; row < nrow; row++) {
+         if((i % 10000) == 0){
+            // if(verbose){
+               // Rcout << "index is " << i << " distance under the current index " << distance[i] << std::endl;
+            // }
+         }
+         if(i > distance.size()){
+           // Rcout << "Warning: index is larger than the length of the distance vector" << distance[i] << std::endl;
+         }
          if (distance[i] < dc) {
             result[row] += 1;
             result[col] += 1;
@@ -43,5 +51,8 @@ NumericVector nonGaussianLocalDensity(NumericVector distance, int nrow, double d
          i++;
       }
    }
+   // if(verbose){
+   //  Rcout << "last index is " << i << " length of distance is " << distance.size() << "number of rows is " << nrow << "number of columns is " << ncol << std::endl;
+   // }
    return result;
 }

--- a/tests/testthat/generateReference.R
+++ b/tests/testthat/generateReference.R
@@ -93,3 +93,4 @@ gaussianDensityClustReference <- Map(referenceImplementation, dists, dcs, TRUE)
 
 # convenient for debugging, but calling non-exported functions not allowed in CRAN
 # gaussianLocalDensityReference <- Map(f = function(x, y) reference_localDensity(x, y, gaussian = TRUE), dists, estimateDcReference)
+

--- a/tests/testthat/testEquivalenceToReferenceImplementation.R
+++ b/tests/testthat/testEquivalenceToReferenceImplementation.R
@@ -44,3 +44,25 @@ test_that("Test equivalence to reference implementation of gaussianDensityClust"
 # test_that("Test equivalence to reference implementation of localDensity", {
 #    expect_equal(gaussianLocalDensityReference, gaussianLocalDensityNewImp)
 # })
+
+#check the findDistValueByRowColInd return the correct index as desired: 
+test_that("Test equivalence to reference implementation of gaussianDensityClust", {
+  test <- dist(c(1:100))
+  test_mat <- as.matrix(test)
+  
+  cluster <- test_mat[, 1]
+  newImp_res <- findDistValueByRowColInd(test, attr(test, 'Size'), which(cluster == 1), which(cluster != 1)) <= 4
+  oriImp_res <- as.vector(test_mat[cluster == 1, cluster != 1] <= 4)
+  
+  expect_equal(newImp_res, oriImp_res )
+  
+  newImp_res <- findDistValueByRowColInd(test, attr(test, 'Size'), which(cluster == 4), which(cluster == 5))
+  oriImp_re <- as.vector(test_mat[cluster == 4, cluster == 5])
+  
+  expect_equal(newImp_res, oriImp_re)
+  
+  dist_vals <- findDistValueByRowColInd(test, attr(test, 'Size'), 1:100, 1:100)
+
+  expect_equal(dist_vals, as.vector(test_mat))
+})
+


### PR DESCRIPTION
I have made the following changes to enable the package to deal with big dataset (tested on about 70k samples): 
1. replace int with size_t to declare variable in Rcpp 
2. remove the conversion from dist object to matrix in findClusters.densityCluster 
3. added a findDistValueByRowColInd function writen in Rcpp to accelerate the access of elements in the dist object mentioned above 
4. add verbose for some functions for printing running information and enable findClusters.densityCluster to accept a vector of index as the density peaks 
5. added new code in test.that for testing the findDistValueByRowColInd function 
